### PR TITLE
fix: prevent shell injection in update-versions script

### DIFF
--- a/scripts/update-versions.mjs
+++ b/scripts/update-versions.mjs
@@ -11,7 +11,7 @@
  * Usage: node scripts/update-versions.mjs [--dry-run]
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
 import { join, basename } from "node:path";
 
@@ -35,8 +35,9 @@ function getSkillDirs() {
 function getGitLog(skillDir) {
   const rel = skillDir.replace(ROOT + "/", "");
   try {
-    const out = execSync(
-      `git log --oneline --reverse --format="%s" -- "${rel}"`,
+    const out = execFileSync(
+      "git",
+      ["log", "--oneline", "--reverse", "--format=%s", "--", rel],
       { cwd: ROOT, encoding: "utf-8" }
     );
     return out


### PR DESCRIPTION
### Motivation
- Close a command-injection vector in `scripts/update-versions.mjs` where unsanitized skill directory names were interpolated into a shell command for `git log`, allowing command substitution from malicious directory names.

### Description
- Replace `execSync` with `execFileSync` and invoke `git` with an explicit argv array (`["log","--oneline","--reverse","--format=%s","--", rel]`) so directory names are passed as literal arguments and cannot perform shell substitution.
- Preserve existing behavior and output formatting for deriving and updating skill `metadata.json` versions.

### Testing
- Ran `node scripts/update-versions.mjs --dry-run` successfully and observed the expected version update summary without modifying files.
- Created a malicious directory named `skills/.experimental/evil$(touch PWNED)` with a `metadata.json`, ran the script in dry-run mode, and verified that `PWNED` was not created, confirming the injection was mitigated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7f018a708322aae9f73a69846b12)