### PR TITLE
fix: correct broken nginx debug companion skill link

### DIFF
--- a/skills/.experimental/nginx-c-module-debug/SKILL.md
+++ b/skills/.experimental/nginx-c-module-debug/SKILL.md
@@ -7,7 +7,7 @@ description: nginx C module debugging guidelines based on the official nginx dev
 
 Comprehensive debugging guide for nginx C modules, derived from the official nginx development documentation and production debugging experience. Contains 45 rules across 8 categories, prioritized by impact to guide systematic diagnosis of crashes, memory bugs, and behavioral issues in nginx modules.
 
-**Companion skills**: This skill complements [nginx-c-modules](../nginx-c-modules/SKILL.md) (correctness) and [nginx-c-module-perf-reliability](../nginx-c-perf/SKILL.md) (performance). This skill covers **debugging and diagnosis**.
+**Companion skills**: This skill complements [nginx-c-modules](../nginx-c-modules/SKILL.md) (correctness) and [nginx-c-module-perf-reliability](../nginx-c-module-perf/SKILL.md) (performance). This skill covers **debugging and diagnosis**.
 
 ## When to Apply
 


### PR DESCRIPTION
### Motivation
- Fix a broken companion link in `skills/.experimental/nginx-c-module-debug/SKILL.md` that still referenced the old `../nginx-c-perf/SKILL.md` after the directory was renamed to `nginx-c-module-perf`.

### Description
- Update the companion skill link on line 10 of `skills/.experimental/nginx-c-module-debug/SKILL.md` to point to `../nginx-c-module-perf/SKILL.md`; this is a one-line, documentation-only change.

### Testing
- Ran automated checks including `nl -ba skills/.experimental/nginx-c-module-debug/SKILL.md | sed -n '1,30p'` with `test -f` to confirm the old path was missing and the new path exists, `git diff` to verify the edit, `rg` to search for the old/new references, and committed the file; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7d691e4c8322912c9afaf1f2c40b)