### PR TITLE
ci: pin GitHub Actions in validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   validate-skills:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.2
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '20'
       - name: Validate all skills


### PR DESCRIPTION
### Motivation
- Reduce CI supply‑chain risk by avoiding mutable action tags (`actions/checkout@v4`, `actions/setup-node@v4`) and by limiting workflow token scope.

### Description
- Update `.github/workflows/ci.yml` to pin `actions/checkout` and `actions/setup-node` to immutable commit SHAs and add a least‑privilege `permissions` block (`contents: read`) for the validation job.

### Testing
- Ran the repository validation script `./scripts/skills-ref validate-all`, which completed successfully with `93/93 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8072541c8322b5ccde04a6691ca1)