### PR TITLE
docs: align curated skill READMEs with migrated `references/` layout

### DIFF
--- a/skills/.curated/ui-design/README.md
+++ b/skills/.curated/ui-design/README.md
@@ -23,16 +23,18 @@ ui-ux-frontend-design/
 ├── AGENTS.md          # Full compiled guide
 ├── metadata.json      # Version and references
 ├── README.md          # This file
-└── rules/
-    ├── _sections.md   # Category definitions
-    ├── access-*.md    # Accessibility rules (7)
-    ├── cwv-*.md       # Core Web Vitals rules (6)
-    ├── layout-*.md    # Layout rules (6)
-    ├── resp-*.md      # Responsive design rules (5)
-    ├── typo-*.md      # Typography rules (5)
-    ├── color-*.md     # Color rules (4)
-    ├── form-*.md      # Form rules (5)
-    └── anim-*.md      # Animation rules (4)
+├── references/
+│   ├── _sections.md   # Category definitions
+│   ├── access-*.md    # Accessibility rules (7)
+│   ├── cwv-*.md       # Core Web Vitals rules (6)
+│   ├── layout-*.md    # Layout rules (6)
+│   ├── resp-*.md      # Responsive design rules (5)
+│   ├── typo-*.md      # Typography rules (5)
+│   ├── color-*.md     # Color rules (4)
+│   ├── form-*.md      # Form rules (5)
+│   └── anim-*.md      # Animation rules (4)
+└── assets/templates/
+    └── _template.md   # Rule template
 ```
 
 ## Getting Started
@@ -41,7 +43,7 @@ ui-ux-frontend-design/
 # Install dependencies (from repo root)
 pnpm install
 
-# Build AGENTS.md from rules
+# Build AGENTS.md from references
 pnpm build
 
 # Validate skill structure
@@ -50,8 +52,8 @@ pnpm validate
 
 ## Creating a New Rule
 
-1. Choose the appropriate category from `rules/_sections.md`
-2. Create a new file: `rules/{prefix}-{description}.md`
+1. Choose the appropriate category from `references/_sections.md`
+2. Create a new file: `references/{prefix}-{description}.md`
 3. Use the template structure (see below)
 4. Run `pnpm build` to regenerate AGENTS.md
 5. Run `pnpm validate` to check for errors
@@ -102,7 +104,7 @@ Reference: [Link](url)
 
 Rules follow the pattern: `{prefix}-{description}.md`
 
-- `prefix`: Category identifier (3-8 chars) from _sections.md
+- `prefix`: Category identifier (3-8 chars) from `references/_sections.md`
 - `description`: Kebab-case description of the rule
 
 Examples:

--- a/skills/.curated/vitest/README.md
+++ b/skills/.curated/vitest/README.md
@@ -27,17 +27,18 @@ vitest/
 ├── AGENTS.md             # Compiled comprehensive guide
 ├── metadata.json         # Version and references
 ├── README.md             # This file
-└── rules/
-    ├── _sections.md      # Category definitions
-    ├── _template.md      # Rule template
-    ├── async-*.md        # Async pattern rules
-    ├── setup-*.md        # Setup and isolation rules
-    ├── mock-*.md         # Mocking pattern rules
-    ├── perf-*.md         # Performance rules
-    ├── snap-*.md         # Snapshot rules
-    ├── env-*.md          # Environment rules
-    ├── assert-*.md       # Assertion rules
-    └── org-*.md          # Organization rules
+├── references/
+│   ├── _sections.md      # Category definitions
+│   ├── async-*.md        # Async pattern rules
+│   ├── setup-*.md        # Setup and isolation rules
+│   ├── mock-*.md         # Mocking pattern rules
+│   ├── perf-*.md         # Performance rules
+│   ├── snap-*.md         # Snapshot rules
+│   ├── env-*.md          # Environment rules
+│   ├── assert-*.md       # Assertion rules
+│   └── org-*.md          # Organization rules
+└── assets/templates/
+    └── _template.md      # Rule template
 ```
 
 ## Usage
@@ -48,7 +49,7 @@ Reference `SKILL.md` for quick navigation or `AGENTS.md` for the complete compil
 
 ### For Humans
 
-Browse individual rule files in the `rules/` directory for detailed explanations and code examples.
+Browse individual rule files in the `references/` directory for detailed explanations and code examples.
 
 ## Key Patterns
 


### PR DESCRIPTION
### Motivation

- The recent refactor moved rule files into `references/` and templates into `assets/templates/`, but some curated skill READMEs still documented the old `rules/` layout causing contributor confusion. 
- The goal is to update documentation to match the repository structure so new rules are created in the correct location and build/validation guidance is accurate. 

### Description

- Updated `skills/.curated/ui-design/README.md` to replace the `rules/` tree with a `references/` tree and to include `assets/templates/_template.md` as the rule template. 
- Updated `skills/.curated/ui-design/README.md` build and new-rule instructions to reference `references/_sections.md` and `references/{prefix}-{description}.md` instead of `rules/`. 
- Updated `skills/.curated/vitest/README.md` to replace `rules/` references with `references/` and to point human-facing guidance to `references/` and `assets/templates/_template.md`.

### Testing

- Ran a content search for stale `rules/` mentions in the updated files using `rg` and confirmed no remaining stale `rules/` references in the modified sections (succeeded). 
- Verified documented paths exist with directory/file checks (`test -d skills/.curated/ui-design/references`, `test -d skills/.curated/vitest/references`, and `test -f skills/.curated/vitest/assets/templates/_template.md`) and all returned success. 
- Reviewed the diff for the two README files to confirm the change is documentation-only and minimal (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac820781fc83228ae1bb8bc93cc062)