### PR TITLE
Fix React Effect remount guidance

### DIFF
--- a/skills/.curated/react/metadata.json
+++ b/skills/.curated/react/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.4",
+  "version": "1.2.5",
   "organization": "React Best Practices",
   "technology": "React",
   "date": "May 2026",

--- a/skills/.curated/react/references/conc-concurrent-safe.md
+++ b/skills/.curated/react/references/conc-concurrent-safe.md
@@ -18,7 +18,7 @@ tags: conc, render-purity, side-effects, idempotent-render
 - Reading `window.innerWidth`, `document.cookie`, or other browser-only globals directly in render — works once, breaks under SSR and breaks again under interrupted renders.
 - A `Math.random()` or `Date.now()` value persisted into a `useState` initializer's body (the unwrapped form) instead of the lazy initializer — value changes on every render attempt.
 
-The canonical resolution: side effects go in `useEffect`/`useLayoutEffect`; external state reads go through `useSyncExternalStore`; stable identifiers come from `useId` or `useRef`; "once on mount" intent is rare and should be expressed via an effect with an empty deps and ref-guarded body, not via render-body code.
+The canonical resolution: synchronization with external systems goes in `useEffect`/`useLayoutEffect` with complete dependencies and cleanup that mirrors setup; external state reads go through `useSyncExternalStore`; stable identifiers come from `useId` or `useRef`; app initialization belongs at module scope or in a framework boot hook. Effects must remain correct across a setup → cleanup → setup cycle.
 
 **Incorrect (side effects during render):**
 


### PR DESCRIPTION
Fixes #10.

## What changed

- Replaced the ref-guarded "once on mount" recommendation with React's setup → cleanup → setup lifecycle invariant.
- Routed app initialization to module scope or a framework boot hook, consistent with the skill's existing Effects taxonomy.
- Bumped the React skill patch version from 1.2.4 to 1.2.5.

This keeps the render-purity rule focused while ensuring Effect guidance agrees with React 19.2 Strict Mode behavior.

Official references:

- https://react.dev/reference/react/useEffect
- https://react.dev/learn/synchronizing-with-effects
- https://react.dev/learn/you-might-not-need-an-effect

## Validation

- `scripts/skills-ref validate skills/.curated/react` — passed with 0 warnings
- `npm run validate` — 205/205 skills passed
- `npm test` — 11/11 tests passed
- `node scripts/check-versions.mjs` — React 1.2.5 reports `OK`
- `scripts/generate-readme-tables --update` — no README diff
- isolated `npx skills add ... --skill react --agent codex --yes --copy` — installed the corrected reference byte-for-byte

## Authoring audit

| Rule | Observable check |
| --- | --- |
| Minimal, tracked source change | Diff contains only the affected reference and `metadata.json` |
| Preserve current React semantics | Wording matches React's complete-dependency and mirrored-cleanup contract |
| Erase rejected-design residue | The active React skill contains no ref-guarded "once on mount" recommendation |
| Keep examples and routing coherent | Existing app-initialization and cleanup references agree with the replacement |
| Keep generated navigation current | README generator produced no diff |
